### PR TITLE
feat: 使用 Docker 常驻容器执行定时同步

### DIFF
--- a/DAILY_SYNC.md
+++ b/DAILY_SYNC.md
@@ -2,9 +2,110 @@
 
 `daily_sync` 是一个持续运行的 Docker 容器，用于自动每日同步体重数据到 Garmin Connect。
 
-## 前置
+## 前置要求
 
-### 构建镜像
+### 1. 配置文件准备
+
+#### 1.1 文件结构确认
+
+请确认项目目录下已有 `config/` 和 `data/` 文件夹，并按如下文件树：
+
+```tree
+garmin-weight-sync/
+├── config/
+│   ├── users.json          # 您的配置文件（含密码，与 xiaomi token）
+├── data/
+│   ├── .garth/         # 您的配置文件（garmin token）
+│   ├── garmin-fit/         # 生成的 FIT 文件
+│   ├── weight_data_*.json  # 数据备份
+│   └── sync.log            # 定时任务日志（如设置）
+```
+
+#### 1.2 配置文件创建
+
+如不存在，请先配置文件：
+
+1. 复制配置文件模板：
+
+```bash
+# Linux/Mac
+cp config/users.json.template config/users.json
+
+# Windows（在文件管理器中操作）
+# 进入 config 文件夹，复制 users.json 到 ./config
+```
+
+#### 1.3 配置文件填写
+
+2. 使用文本编辑器打开 `config/users.json`，填写您的账户信息：
+
+```json
+{
+    "users": [
+        {
+            "username": "您的手机号或邮箱",
+            "password": "小米账号密码",
+            "model": "yunmai.scales.ms103",
+            "token": {
+                "userId": "",
+                "passToken": "",
+                "ssecurity": ""
+            },
+            "garmin": {
+                "email": "您的佳明账号邮箱",
+                "password": "佳明账号密码",
+                "domain": "CN"
+            }
+        }
+    ]
+}
+```
+
+**重要参数说明：**
+
+| 参数 | 说明 | 示例值 |
+|------|------|--------|
+| `username` | 小米账号手机号或邮箱 | `13800138000` 或 `example@qq.com` |
+| `password` | 小米账号密码 | `your_password` |
+| `model` | 设备型号，小米体脂秤 S400 填此项 | `yunmai.scales.ms103` |
+| `garmin.domain` | 佳明服务器区域 | 中国区填 `CN`，国际区填 `COM` |
+| `token` | 首次留空，登录后自动填充 | 留空即可 |
+
+#### 1.4 首次登录授权
+
+3. 首次登录（获取小米/佳明授权）（请在构建镜像完成后执行）
+
+对小米授权：
+
+由于小米账号需要验证码登录，构建镜像后，第一次需要运行登录服务：
+
+```bash
+docker-compose --profile login run --rm login
+```
+
+**登录流程：**
+
+1. 程序会提示输入小米账号密码（已在配置文件中）
+2. 如果需要图形验证码，程序会自动在浏览器中打开验证码图片
+3. 看清验证码后，在终端中输入并回车
+4. 如果开启了二次验证（2FA），输入手机收到的 6 位验证码
+5. 登录成功后，程序会自动更新 `config/users.json` 中的 token 信息
+
+看到 `Login SUCCESS!` 提示后，表示授权成功，以后不需要再运行此步骤。
+
+对佳明授权：
+
+运行时，程序首先在同步前从 data/.garth/ 下读取持久化 garmin token，如不存在，则会自动更新并存储信息，故直接运行
+
+```bash
+docker-compose up -d daily_sync
+```
+
+即可
+
+### 2. 镜像构建
+
+#### 2.1 构建镜像
 
 如果项目更新了代码（如新增 `daily_sync.py`），需要本地构建镜像：
 
@@ -14,7 +115,7 @@ docker-compose build --no-cache
 
 构建完成后重新启动容器即可使用最新代码。
 
-### 删除镜像
+#### 2.2 删除镜像
 
 删除本地构建的镜像：
 

--- a/DAILY_SYNC.md
+++ b/DAILY_SYNC.md
@@ -1,0 +1,284 @@
+# Daily Sync 使用指南
+
+`daily_sync` 是一个持续运行的 Docker 容器，用于自动每日同步体重数据到 Garmin Connect。
+
+## 前置
+
+### 构建镜像
+
+如果项目更新了代码（如新增 `daily_sync.py`），需要本地构建镜像：
+
+```bash
+docker-compose build --no-cache
+```
+
+构建完成后重新启动容器即可使用最新代码。
+
+### 删除镜像
+
+删除本地构建的镜像：
+
+```bash
+# 删除 daily_sync 相关的镜像
+docker-compose down daily_sync
+docker image rm lesliehwang/garmin-weight-sync:latest
+
+# 或重新构建时覆盖旧镜像
+docker-compose build --no-cache
+```
+
+## 快速开始
+
+### 启动容器
+
+```bash
+docker-compose up -d daily_sync
+```
+
+### 查看状态
+
+```bash
+docker-compose ps
+```
+
+### 查看日志
+
+```bash
+# 实时日志
+docker-compose logs -f daily_sync
+
+# 最后 100 行
+docker-compose logs -n 100 daily_sync
+
+# 保存日志到文件
+docker-compose logs daily_sync > sync_logs.txt
+```
+
+## 工作原理
+
+1. **启动延迟**：容器启动后会延迟 5 分钟（可自定义）
+2. **首次同步**：延迟后执行第一次同步
+3. **周期执行**：之后每 24 小时（可自定义）执行一次同步
+4. **错误处理**：同步失败时会在 1 小时后自动重试
+5. **自动重启**：配置了 `restart: unless-stopped`，容器意外停止时会自动重启
+
+## 配置参数
+
+### Docker Compose 配置
+
+编辑 `docker-compose.yml` 中的 `daily_sync` 服务的 `command` 字段：
+
+```yaml
+command: ["python", "src/daily_sync.py", "--config", "config/users.json", "--sync", "--delay", "300", "--interval", "86400"]
+```
+
+### 参数说明
+
+| 参数 | 说明 | 示例 | 默认值 |
+|------|------|------|--------|
+| `--config` | 配置文件路径 | `config/users.json` | `config/users.json` |
+| `--sync` | 启用 Garmin 上传 | （无值，仅作为标志） | 不启用 |
+| `--delay` | 启动延迟（秒） | `600` 表示 10 分钟 | `300`（5 分钟） |
+| `--interval` | 同步间隔（秒） | `43200` 表示 12 小时 | `86400`（24 小时） |
+
+### 常见配置示例
+
+#### 每 6 小时同步一次
+
+```yaml
+command: ["python", "src/daily_sync.py", "--config", "config/users.json", "--sync", "--delay", "300", "--interval", "21600"]
+```
+
+#### 每 12 小时同步一次，延迟 10 分钟
+
+```yaml
+command: ["python", "src/daily_sync.py", "--config", "config/users.json", "--sync", "--delay", "600", "--interval", "43200"]
+```
+
+#### 启动后立即同步
+
+```yaml
+command: ["python", "src/daily_sync.py", "--config", "config/users.json", "--sync", "--delay", "0", "--interval", "86400"]
+```
+
+## 日志查看
+
+### 实时日志
+
+```bash
+docker-compose logs -f daily_sync
+```
+
+输出示例：
+
+```
+2024-05-12 10:30:45,123 - root - INFO - Daily Sync Runner started with config: config/users.json
+2024-05-12 10:30:45,124 - root - INFO - Initial delay: 300s, Sync interval: 86400s
+2024-05-12 10:30:45,125 - root - INFO - Sync to Garmin: enabled
+2024-05-12 10:30:45,126 - root - INFO - Delaying start for 300 seconds...
+2024-05-12 10:35:45,456 - root - INFO - Starting sync with config: config/users.json
+2024-05-12 10:35:50,789 - root - INFO - Sync completed at 2024-05-12 10:35:50.789123
+2024-05-12 10:35:50,890 - root - INFO - Sync successful
+2024-05-12 10:35:50,891 - root - INFO - Next sync scheduled for 2024-05-13 10:35:50.891123
+```
+
+### 历史日志
+
+```bash
+# 查看最后 50 行
+docker-compose logs -n 50 daily_sync
+
+# 查看特定时间段的日志（需要手动保存）
+docker-compose logs daily_sync > /tmp/full_logs.txt
+grep "2024-05-12 10:" /tmp/full_logs.txt
+```
+
+## 管理操作
+
+### 启动容器
+
+```bash
+docker-compose up -d daily_sync
+```
+
+### 停止容器（暂停）
+
+```bash
+docker-compose stop daily_sync
+```
+
+### 启动已停止的容器
+
+```bash
+docker-compose start daily_sync
+```
+
+### 重启容器
+
+```bash
+docker-compose restart daily_sync
+```
+
+### 删除容器
+
+```bash
+docker-compose down daily_sync
+```
+
+### 查看容器详细信息
+
+```bash
+docker-compose ps daily_sync
+```
+
+## 故障排查
+
+### 容器无法启动
+
+**症状**：运行 `docker-compose up -d daily_sync` 后没有响应，或提示 "can't open file '/app/src/daily_sync.py'"
+
+**解决方案**：
+1. 查看错误日志：`docker-compose logs daily_sync`
+2. 如果提示找不到 `daily_sync.py`，需要本地构建：`docker-compose build --no-cache`
+3. 确保配置文件存在：`config/users.json` 是否存在
+4. 尝试重建：`docker-compose up -d --build daily_sync`
+
+### 同步始终失败
+
+**症状**：日志显示 "Sync failed"
+
+**解决方案**：
+1. 检查用户配置：`cat config/users.json`
+2. 验证 token 有效性（检查 token 是否已过期）
+3. 重新登录获取新 token：`docker-compose --profile login run --rm login`
+4. 检查网络连接和防火墙设置
+
+### 容器频繁重启
+
+**症状**：`docker-compose ps` 显示容器状态不稳定
+
+**解决方案**：
+1. 查看详细日志：`docker-compose logs -n 100 daily_sync`
+2. 检查是否有异常错误
+3. 如果是因为配置问题，修复配置后重新启动
+
+### 日志过多导致磁盘占满
+
+**症状**：Docker 日志占用大量磁盘空间
+
+**解决方案**：
+```bash
+# 清理 Docker 日志
+docker system prune --volumes
+
+# 限制日志大小（编辑 docker-compose.yml）
+logging:
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+```
+
+## 与其他同步方式的比较
+
+| 方式 | 优点 | 缺点 | 适用场景 |
+|------|------|------|---------|
+| **daily_sync 容器** | 无需外部工具，自动重启，完整日志 | 需要 Docker | 长期持续运行 |
+| **一次性同步** | 简单快速，手动控制 | 需要每次手动运行 | 测试、临时使用 |
+| **Windows 任务计划** | 系统集成，无需 Docker | 需要管理员权限 | Windows 专用 |
+| **Linux crontab** | 系统原生，轻量级 | 需要 crontab 知识 | Linux 专用 |
+
+## 性能注意事项
+
+- **CPU**：每次同步占用 100-200M 内存，CPU 占用较低
+- **网络**：每次同步需要上下行网络，建议在网络稳定时间段运行
+- **磁盘**：FIT 文件和备份数据存储在 `data/` 目录
+- **日志**：日志会持续写入，建议定期检查磁盘空间
+
+## 升级和更新
+
+### 本地构建（项目更新）
+
+当项目新增功能或文件时，需要本地构建新镜像：
+
+```bash
+docker-compose build --no-cache
+docker-compose restart daily_sync
+```
+
+### 拉取最新镜像
+
+从 Docker Hub 更新预构建镜像：
+
+```bash
+docker-compose pull daily_sync
+docker-compose up -d daily_sync
+```
+
+### 清理镜像
+
+删除不使用的旧镜像释放磁盘空间：
+
+```bash
+# 删除所有未使用的镜像
+docker image prune -a
+
+# 删除特定镜像
+docker image rm lesliehwang/garmin-weight-sync:latest
+```
+
+### 版本回滚
+
+```bash
+# 查看镜像历史
+docker image history lesliehwang/garmin-weight-sync
+
+# 指定特定版本
+# 编辑 docker-compose.yml，修改 image 为特定版本标签
+```
+
+## 相关文档
+
+- [Docker 部署指南](DOCKER_SETUP.md) - 完整的 Docker 使用说明
+- [项目 README](README.md) - 项目概述
+- [使用说明](USAGE.md) - 功能和特性说明

--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -113,7 +113,9 @@ cp config/users.json.template config/users.json
 | `garmin.domain` | 佳明服务器区域 | 中国区填 `CN`，国际区填 `COM` |
 | `token` | 首次留空，登录后自动填充 | 留空即可 |
 
-### 第三步：拉取 Docker 镜像
+### 第三步：拉取 Docker 镜像（或本地构建）
+
+#### 拉取 Docker 镜像
 
 本项目已将预构建的镜像托管到 Docker Hub，无需本地构建，直接拉取即可：
 
@@ -126,6 +128,29 @@ docker-compose pull
 ```
 Pulling sync ... done
 Pulling login ... done
+```
+
+#### 本地构建（如项目有更新）
+
+如果项目添加了新功能或文件（如 `daily_sync.py`），Docker Hub 的预构建镜像可能不包含这些更新。此时需要本地构建：
+
+```bash
+docker-compose build --no-cache
+```
+
+这会基于本地的 `Dockerfile` 和源代码重新构建镜像。首次构建可能需要 2-3 分钟。
+
+#### 删除镜像（当需要时）
+
+删除本地构建的镜像：
+
+```bash
+# 删除 daily_sync 相关的镜像
+docker-compose down daily_sync
+docker image rm lesliehwang/garmin-weight-sync:latest
+
+# 或重新构建时覆盖旧镜像
+docker-compose build --no-cache
 ```
 
 ### 第四步：首次登录（获取小米授权）
@@ -184,6 +209,76 @@ ls -la data/weight_data_*.json
 
 如果您希望每天自动同步，可以设置定时任务。
 
+### 使用持续运行的容器（推荐）
+
+此方式在 Docker 中持续运行一个容器，自动每日同步数据。容器支持自动重启，无需外部定时任务。
+
+#### 启动持续同步容器
+
+1. 确保已完成首次登录（第四步）。
+2. 运行以下命令启动容器：
+   ```bash
+   docker-compose up -d daily_sync
+   ```
+   - `-d` 表示后台运行（detached mode）。
+   - 容器启动后会**延迟 5 分钟**，然后开始同步。
+   - 之后每 **24 小时** 自动同步一次。
+
+#### 管理 daily_sync 容器
+
+| 操作 | 命令 | 说明 |
+|------|------|------|
+| 启动容器 | `docker-compose up -d daily_sync` | 后台启动，会立即延迟 5 分钟后开始 |
+| 查看状态 | `docker-compose ps` | 显示所有容器状态 |
+| 查看日志 | `docker-compose logs -f daily_sync` | 实时查看同步日志，按 `Ctrl+C` 退出 |
+| 停止容器 | `docker-compose stop daily_sync` | 暂停容器（可稍后重启） |
+| 重启容器 | `docker-compose restart daily_sync` | 重启容器 |
+| 删除容器 | `docker-compose down daily_sync` | 完全停止并删除容器 |
+
+#### 自定义同步参数（可选）
+
+如需自定义延迟时间或同步间隔，可修改 `docker-compose.yml` 中 `daily_sync` 的 `command` 参数：
+
+```yaml
+command: ["python", "src/daily_sync.py", "--config", "config/users.json", "--sync", "--delay", "600", "--interval", "43200"]
+```
+
+参数说明：
+- `--delay 600`：启动后延迟 600 秒（10 分钟）再进行首次同步。默认 300 秒。
+- `--interval 43200`：每次同步间隔 43200 秒（12 小时）。默认 86400 秒（24 小时）。
+
+#### 日志保存
+
+容器的日志可以通过以下方式查看：
+
+```bash
+# 实时日志
+docker-compose logs -f daily_sync
+
+# 查看最后 100 行
+docker-compose logs -n 100 daily_sync
+
+# 保存日志到文件
+docker-compose logs daily_sync > sync_logs.txt
+```
+
+#### 重启策略
+
+`daily_sync` 容器配置了 `restart: unless-stopped`，表示：
+- 容器意外停止时**自动重启**。
+- 只有通过 `docker-compose stop` 或 `docker-compose down` 才会停止。
+- Docker 守护进程重启后，容器也会自动启动。
+
+#### 容器重启流程
+
+如果容器因任何原因重启：
+1. 容器启动
+2. 延迟 5 分钟（防止频繁重启时立即运行）
+3. 执行同步
+4. 等待 24 小时后继续同步
+
+---
+
 ### Windows 用户（任务计划程序）
 
 1. 按 `Win + R`，输入 `taskschd.msc` 并回车
@@ -240,10 +335,19 @@ ls -la data/weight_data_*.json
 | 操作 | 命令 |
 |------|------|
 | 拉取镜像 | `docker-compose pull` |
+| 本地构建镜像 | `docker-compose build --no-cache` |
 | 首次登录 | `docker-compose --profile login run --rm login` |
 | 执行同步 | `docker-compose run --rm sync` |
 | 查看日志 | `docker-compose logs sync` |
 | 停止所有容器 | `docker-compose down` |
+
+### daily_sync 容器命令
+
+| 操作 | 命令 |
+|------|------|
+| 启动持续同步 | `docker-compose up -d daily_sync` |
+| 查看 daily_sync 日志 | `docker-compose logs -f daily_sync` |
+| 停止 daily_sync | `docker-compose stop daily_sync` |
 
 ---
 
@@ -258,10 +362,15 @@ garmin-weight-sync/
 │   ├── garmin-fit/         # 生成的 FIT 文件
 │   ├── weight_data_*.json  # 数据备份
 │   └── sync.log            # 定时任务日志（如设置）
-├── src/                    # 源代码
+├── src/
+│   ├── main.py             # 主同步程序
+│   ├── daily_sync.py       # 持续同步程序（新增）
+│   └── ...                 # 其他源代码
 ├── Dockerfile              # Docker 镜像定义
 ├── docker-compose.yml      # Docker 服务编排
-└── DOCKER_SETUP.md         # 本文档
+├── DOCKER_SETUP.md         # Docker 部署指南（本文档）
+├── DAILY_SYNC.md           # Daily Sync 使用指南（新增）
+└── README.md               # 项目说明
 ```
 
 ---
@@ -310,6 +419,70 @@ cat data/sync.log
 docker compose run --rm sync
 ```
 （注意是 `docker compose` 而不是 `docker-compose`）
+
+### daily_sync 相关问题
+
+#### Q: daily_sync 容器无法启动
+
+**症状**：运行 `docker-compose up -d daily_sync` 后没有响应，或提示 "can't open file '/app/src/daily_sync.py'"
+
+**解决方案**：
+1. 查看错误日志：`docker-compose logs daily_sync`
+2. 如果提示找不到 `daily_sync.py`，需要本地构建：`docker-compose build --no-cache`
+3. 确保配置文件存在：`config/users.json` 是否存在
+4. 尝试重建：`docker-compose up -d --build daily_sync`
+
+#### Q: daily_sync 容器启动后没有同步怎么办？
+
+**A:** daily_sync 容器启动后会延迟 5 分钟，然后才进行首次同步。您可以：
+1. 使用 `docker-compose logs -f daily_sync` 查看实时日志，等待同步开始。
+2. 如果日志显示错误，检查 `config/users.json` 配置是否正确。
+3. 确保已完成首次登录（第四步）。
+
+#### Q: daily_sync 容器中的同步失败怎么办？
+
+**A:** 容器会自动在 1 小时后重试。您也可以：
+1. 查看日志：`docker-compose logs -f daily_sync`
+2. 检查网络连接是否正常
+3. 验证 `config/users.json` 中的用户名、密码和 token 是否有效
+4. 必要时重新运行登录：`docker-compose --profile login run --rm login`
+
+#### Q: 如何暂停 daily_sync 的自动同步？
+
+**A:** 使用以下命令暂停容器（不会删除容器配置）：
+```bash
+docker-compose stop daily_sync
+```
+要重新启动，使用：
+```bash
+docker-compose restart daily_sync
+```
+
+#### Q: daily_sync 容器重启时会丢失数据吗？
+
+**A:** 不会。所有数据都存储在 `config/` 和 `data/` 目录中，这些目录已通过 volumes 映射到容器内，数据不会丢失。
+
+#### Q: 如何修改 daily_sync 的同步间隔？
+
+**A:** 修改 `docker-compose.yml` 中 `daily_sync` 服务的 `command` 参数：
+```yaml
+command: ["python", "src/daily_sync.py", "--config", "config/users.json", "--sync", "--interval", "43200"]
+```
+其中 `--interval 43200` 表示 12 小时（单位为秒）。修改后重启容器：
+```bash
+docker-compose restart daily_sync
+```
+
+#### Q: 运行 daily_sync 时提示 "can't open file '/app/src/daily_sync.py': No such file or directory"
+
+**A:** 这是因为 Docker Hub 的预构建镜像是旧版本，不包含 `daily_sync.py` 文件。需要本地构建镜像：
+```bash
+docker-compose build --no-cache
+```
+构建完成后重新启动容器：
+```bash
+docker-compose up -d daily_sync
+```
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-version: '3.8'
+# version: '3.8'
 
 services:
   # Login service - run once for initial setup
   login:
+    build: .
     image: lesliehwang/garmin-weight-sync:latest
     container_name: garmin-sync-login
     volumes:
@@ -16,9 +17,21 @@ services:
 
   # Sync service - run periodically
   sync:
+    build: .
     image: lesliehwang/garmin-weight-sync:latest
     container_name: garmin-sync
     volumes:
       - ./config:/app/config
       - ./data:/app/data
     command: ["python", "src/main.py", "--config", "config/users.json", "--sync"]
+
+  # Daily sync service - run continuously with daily sync
+  daily_sync:
+    build: .
+    image: lesliehwang/garmin-weight-sync:latest
+    container_name: garmin-daily-sync
+    volumes:
+      - ./config:/app/config
+      - ./data:/app/data
+    restart: unless-stopped
+    command: ["python", "src/daily_sync.py", "--config", "config/users.json", "--sync", "--delay", "300", "--interval", "86400"]

--- a/src/daily_sync.py
+++ b/src/daily_sync.py
@@ -1,0 +1,77 @@
+import time
+import subprocess
+import datetime
+import argparse
+import sys
+import logging
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def run_sync(config_path, sync_flag):
+    """运行同步命令"""
+    cmd = ["python", "src/main.py", "--config", config_path]
+    if sync_flag:
+        cmd.append("--sync")
+    try:
+        logger.info(f"Starting sync with config: {config_path}")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        logger.info(f"Sync completed at {datetime.datetime.now()}")
+        if result.stdout:
+            logger.info(f"STDOUT: {result.stdout}")
+        if result.stderr:
+            logger.warning(f"STDERR: {result.stderr}")
+        if result.returncode == 0:
+            logger.info("Sync successful")
+        else:
+            logger.error(f"Sync failed with return code: {result.returncode}")
+        return result.returncode == 0
+    except Exception as e:
+        logger.error(f"Error running sync: {e}")
+        return False
+
+def main():
+    parser = argparse.ArgumentParser(description="Daily Sync Runner")
+    parser.add_argument("--config", default="config/users.json",
+                        help="Path to users.json config file")
+    parser.add_argument("--sync", action="store_true",
+                        help="Enable sync to Garmin")
+    parser.add_argument("--delay", type=int, default=300,
+                        help="Delay in seconds before first sync (default: 300)")
+    parser.add_argument("--interval", type=int, default=86400,
+                        help="Interval in seconds between syncs (default: 86400 = 24 hours)")
+    args = parser.parse_args()
+
+    logger.info(f"Daily Sync Runner started with config: {args.config}")
+    logger.info(f"Initial delay: {args.delay}s, Sync interval: {args.interval}s")
+    logger.info(f"Sync to Garmin: {'enabled' if args.sync else 'disabled'}")
+    
+    # 延迟启动（防止容器重启时立即运行）
+    logger.info(f"Delaying start for {args.delay} seconds...")
+    time.sleep(args.delay)
+
+    while True:
+        try:
+            success = run_sync(args.config, args.sync)
+            if success:
+                next_sync = datetime.datetime.now() + datetime.timedelta(seconds=args.interval)
+                logger.info(f"Next sync scheduled for {next_sync}")
+            else:
+                logger.warning("Sync failed, retrying in 1 hour...")
+                time.sleep(3600)  # 如果失败，1小时后重试
+                continue
+            time.sleep(args.interval)
+        except KeyboardInterrupt:
+            logger.info("Daily Sync Runner stopped by user")
+            break
+        except Exception as e:
+            logger.error(f"Unexpected error in main loop: {e}")
+            logger.info("Retrying in 1 hour...")
+            time.sleep(3600)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
新增基于 Docker 常驻容器的定时自动同步服务 `daily_sync`，无需依赖宿主机 `crontab` 或外部调度工具即可实现自动同步。

支持后台持续运行、定时调度、失败自动重试，同时提供完整 Docker 配置与文档说明。

---

## 主要变更

* 新增 `src/daily_sync.py`

  * 循环执行同步任务
  * 输出标准日志
  * 支持启动延迟与定时间隔配置

* 新增调度参数

  * `--delay`

    * 容器启动后延迟执行（默认 300s）
  * `--interval`

    * 同步间隔（默认 86400s / 24h）

* 增加失败重试机制

  * 同步失败后 1 小时自动重试
  * 推荐配合 Docker `restart: unless-stopped`

* 文档更新

  * 新增 `DAILY_SYNC.md`
  * 更新 `DOCKER_SETUP.md`
  * 补充自动同步配置说明

---

## 如何测试

### 构建镜像

```bash
docker-compose build --no-cache
```

### 启动服务

```bash
docker-compose up -d daily_sync
```

### 查看日志

```bash
docker-compose logs -f daily_sync
```

确认：

* 正常输出 delay / interval 配置
* 首次同步正常触发
* 同步完成后进入下一轮等待